### PR TITLE
Add CCM and backup SRAM support

### DIFF
--- a/memory.ld
+++ b/memory.ld
@@ -36,7 +36,7 @@ SECTIONS {
     . = ALIGN(4);
   } > FLASH
 
-/* Initialized data will be in the FLASH and it will also be in the RAM during runtime */
+  /* Initialized data will be in the FLASH and it will also be in the RAM during runtime */
   .data : {
     _sidata = LOADADDR(.data); /*This returns the flash (LMA) address*/
     _sdata = . ; /* Start of data section in RAM (VMA)*/
@@ -51,6 +51,22 @@ SECTIONS {
     . = ALIGN(4);
     _ebss = . ;
   } > RAM
+
+  /* Uninitialized variables explicitly placed in CCMRAM */
+  .ccmram (NOLOAD) : {
+    _sccmram = .;
+    *(.ccmram*)
+    . = ALIGN(4);
+    _eccmram = .;
+  } > CCMRAM
+
+  /* Uninitialized variables that should persist in backup SRAM */
+  .bkpsram (NOLOAD) : {
+    _sbkpsram = .;
+    *(.bkpsram*)
+    . = ALIGN(4);
+    _ebkpsram = .;
+  } > BKPSRAM
 
   ._user_heap_stack : {
     . = ALIGN(4);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,14 @@ static mut SCORES_GLOBAL: [i32; 5] = [1, 2, 3, 4, 5];
 const NUMBERS: [i32; 5] = [1, 2, 3, 4, 5];
 static mut BUFFER: [u8; 1024] = [0; 1024];
 
+// Placed into CCMRAM for fast access
+#[link_section = ".ccmram"]
+static mut CCM_BUFFER: [u8; 512] = [0; 512];
+
+// Stored in backup SRAM so it survives standby mode
+#[link_section = ".bkpsram"]
+static mut BKP_DATA: [u32; 8] = [0; 8];
+
 #[unsafe(export_name = "main")]
 pub extern "C" fn main() -> ! {
     let mut _total_score: i32 = 0;
@@ -17,7 +25,11 @@ pub extern "C" fn main() -> ! {
         _total_score += score;
     };
 
-    unsafe {BUFFER[0] = 100;}
+    unsafe {
+        BUFFER[0] = 100;
+        CCM_BUFFER[0] = 1;
+        BKP_DATA[0] = 42;
+    }
     loop {
         
     }


### PR DESCRIPTION
## Summary
- link new `.ccmram` and `.bkpsram` sections
- demonstrate usage with small buffers in `main.rs`

## Testing
- `cargo build --verbose` *(fails: missing thumbv7em target)*

------
https://chatgpt.com/codex/tasks/task_e_68478b87fe0483219b489ca9fa7846c2